### PR TITLE
add allow-other-keys to dual_panda-robot-interface :init

### DIFF
--- a/jsk_panda_robot/jsk_panda.rosinstall
+++ b/jsk_panda_robot/jsk_panda.rosinstall
@@ -10,9 +10,9 @@
 
 # Needed for using haptics devices
 - git:
-  local-name: phantom_drivers
-  uri: https://github.com/ykawamura96/Geomagic_Touch_ROS_Drivers.git
-  version: dual_phantom
+    local-name: phantom_drivers
+    uri: https://github.com/ykawamura96/Geomagic_Touch_ROS_Drivers.git
+    version: dual_phantom
 
 - git:
     local-name: franka_ros

--- a/jsk_panda_robot/panda_eus/euslisp/dual_panda-interface.l
+++ b/jsk_panda_robot/panda_eus/euslisp/dual_panda-interface.l
@@ -14,7 +14,7 @@
   )
 (defmethod dual_panda-robot-interface
   (:init
-   (&rest args &key ((:controller-timeout ct) nil))
+   (&rest args &key ((:controller-timeout ct) nil)  &allow-other-keys)
    (prog1
        (send-super* :init :robot dual_panda-robot
                     :joint-states-topic "dual_panda/joint_states"


### PR DESCRIPTION
To read joint states from rosbag, which does not provide JTA service.
cc: @softyanija

```
(load "package://panda_eus/euslisp/dual_panda-interface.l")

(defmethod dual_panda-robot-interface
  (:dummy-controller (&rest args)))
(setq *ri* (instance dual_panda-robot-interface :init
                     :type :dummy-controller))

(do-until-key
 (print (send *ri* :state :potentio-vector))

```