### PR TITLE
Remove rwt teleop in default launch file and fix typos

### DIFF
--- a/jsk_panda_robot/jsk_panda_startup/launch/dual_panda.launch
+++ b/jsk_panda_robot/jsk_panda_startup/launch/dual_panda.launch
@@ -54,10 +54,6 @@
   <!-- vision -->
   <include file="$(find openni2_launch)/launch/openni2.launch" />
 
-  <!-- teleop -->
-  <include file="$(find rwt_image_view)/launch/rwt_image_view.launch"/> 
-  <node pkg="rwt_teleop" type="draw_force_on_image.py" name="draw_force_on_image"/>
-
   <group ns="larm_marker">
     <node pkg="image_view2" type="image_view2" name="image_view2_for_draw_force_on_image" output="log">
       <remap from="image" to="/edgetpu_object_detector/output/image"/>

--- a/jsk_panda_robot/jsk_panda_teleop/launch/start_panda_rt_controller.launch
+++ b/jsk_panda_robot/jsk_panda_teleop/launch/start_panda_rt_controller.launch
@@ -20,8 +20,8 @@
     <arg name="robot"     value="$(find panda_eus)/models/dual_panda_with_handeye.urdf.xacro" />
     <arg name="robot_id"  value="$(arg robot_id)" />
     <arg name="robot_ips" value="$(arg robot_ips)" />
-    <arg name="hw_config_file"   value="$(find jsk_pand_teleop)/config/dual_panda_control_node.yaml"/>
-    <arg name="controllers_file" value="$(find jsk_pand_teleop)/config/dual_panda_controllers.yaml" />
+    <arg name="hw_config_file"   value="$(find jsk_panda_teleop)/config/dual_panda_control_node.yaml"/>
+    <arg name="controllers_file" value="$(find jsk_panda_teleop)/config/dual_panda_controllers.yaml" />
     <arg name="controllers_to_start"     value="rarm_state_controller larm_state_controller dual_arm_cartesian_pose_controller"/>
     <arg name="joint_states_source_list" value="[rarm_state_controller/joint_states, larm_state_controller/joint_states, rarm/franka_gripper/joint_states, larm/franka_gripper/joint_states]"/>
   </include>
@@ -71,8 +71,8 @@
   </node>
 
   <!-- Touch USB to Panda connection -->
-  <node pkg="jsk_pand_teleop" type="phantom_to_panda.py" name="phantom_to_panda" output="screen" args="--connect_pose --connect_force" if="$(arg start_bilateral)"/>
-  <node pkg="jsk_pand_teleop" type="phantom_to_panda.py" name="phantom_to_panda" output="screen" args="--noconnect_pose --noconnect_force" unless="$(arg start_bilateral)"/>
+  <node pkg="jsk_panda_teleop" type="phantom_to_panda.py" name="phantom_to_panda" output="screen" args="--connect_pose --connect_force" if="$(arg start_bilateral)"/>
+  <node pkg="jsk_panda_teleop" type="phantom_to_panda.py" name="phantom_to_panda" output="screen" args="--noconnect_pose --noconnect_force" unless="$(arg start_bilateral)"/>
 
 
 </launch>


### PR DESCRIPTION
Removed rwt teleop in dual_panda.launch beacause we are not using rwt teleop right now, also I fixed some of typos in launch fiels.
